### PR TITLE
Upgrade @hollowverse/common

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "shelljs": "^0.7.8"
   },
   "devDependencies": {
-    "@types/shelljs": "^0.7.4",
     "@types/node": "^8.0.24",
+    "@types/shelljs": "^0.7.4",
     "babel-eslint": "^7.2.3",
     "eslint": "^4.1.1",
     "eslint-config-airbnb": "^15.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,7 +4,7 @@
 
 "@hollowverse/common@https://github.com/hollowverse/common":
   version "1.2.0"
-  resolved "https://github.com/hollowverse/common#2112dbb6b4740fb0d43f3dc0e111d45528e5e64d"
+  resolved "https://github.com/hollowverse/common#1f9a2cfcc3696dc9c47ff3e4fe60796a9dad6286"
   dependencies:
     minimatch "^3.0.4"
     shelljs "^0.7.8"


### PR DESCRIPTION
It turns our yarn will keep a reference in `yarn.lock` to the specific commit that `master` points to at install time, so we will have to upgrade all the repos after every push to `hollowverse/common`.