### PR TITLE
Install git and use yarn in runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir -p ./public
 ADD ./secrets/gcloud.letsEncrypt.json .
 
 # Add the certificate genenration and update scripts and crontab file to the container
-ADD ./cronJobUpdate .
+ADD . .
 
 # Schedule renewal using a cron job
 RUN crontab cronJobUpdate

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,19 @@ RUN \
 # Import the Google Cloud public key
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
-RUN apt-get update -qq && apt-get install -y -qq certbot nodejs cron at google-cloud-sdk
+# Add yarn source
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-RUN npm install -g http-server
+RUN apt-get update -qq && apt-get install -y -qq certbot nodejs cron at google-cloud-sdk yarn git
 
-# Add package.json so this layer can be cached independently
-ADD ./package.json .
+RUN yarn global add http-server
+
+# Add package.json and yarn.lock so this layer can be cached independently
+ADD package.json yarn.lock ./
 
 # Install dependencies for cert.js script
-RUN npm install
+RUN yarn
 
 # This directory will contain domain vertification files
 RUN mkdir -p ./public
@@ -41,7 +45,7 @@ RUN mkdir -p ./public
 ADD ./secrets/gcloud.letsEncrypt.json .
 
 # Add the certificate genenration and update scripts and crontab file to the container
-ADD . .
+ADD ./cronJobUpdate .
 
 # Schedule renewal using a cron job
 RUN crontab cronJobUpdate


### PR DESCRIPTION
We need git because we are using helpers from `@common/hollowverse` in the runtime image. We also install yarn to lock the versions.