### PR TITLE
Fix sync direction on initial rsync

### DIFF
--- a/cert.js
+++ b/cert.js
@@ -13,7 +13,6 @@ const {
 } = require('./config');
 
 const SYNC_ROOT = `/etc/letsencrypt/`;
-const SYNC_COMMAND = `gsutil -q -m rsync -r ${SYNC_ROOT} gs://${STORAGE_BUCKET_ID}/config`;
 
 async function main() {
   const code = await executeCommands([
@@ -21,7 +20,7 @@ async function main() {
     'gcloud auth activate-service-account --key-file /gcloud.letsEncrypt.json',
 
     // Restore previous certificate files from Cloud Storage (if any)
-    SYNC_COMMAND,
+    `gsutil -q -m rsync -r gs://${STORAGE_BUCKET_ID}/config ${SYNC_ROOT}`,
 
     // Create or update Let's Encrypt certificate if needed
     `certbot certonly \
@@ -92,7 +91,7 @@ async function main() {
     },
 
     // Upload the newly created certificate files to Cloud Storage (if any)
-    SYNC_COMMAND,
+    `gsutil -q -m rsync -r ${SYNC_ROOT} gs://${STORAGE_BUCKET_ID}/config`,
   ]);
 
   process.exit(code);


### PR DESCRIPTION
It turns out that the order of the source and destination in the rsync command is important and changes the behavior of the syncing operation. If `/etc/letsencrypt` is empty (which it would on first launch), rsync won't fetch the files from the destination.

This commit changes the order of the first rsync command to force rsync to fetch the files.